### PR TITLE
adding logo link

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -201,6 +201,14 @@
       ]
     },
     {
+      "category": "logo",
+      "values": [
+        {
+          "value": "eegnet-logo_0.png"
+        }
+      ]
+    },
+    {
       "category": "contact",
       "values": [
         {


### PR DESCRIPTION
This PR adds a `logo` entry in the `extraProperties` section of the DATS.json to link to the logo file in the dataset.